### PR TITLE
feat : HTTP의 POST 요청으로 전송할 메세지 폼을 수신하는 기능 구현

### DIFF
--- a/src/main/java/com/example/msglab/adapter/MessageController.java
+++ b/src/main/java/com/example/msglab/adapter/MessageController.java
@@ -1,0 +1,17 @@
+package com.example.msglab.adapter;
+
+import org.apache.logging.log4j.message.Message;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MessageController {
+    @PostMapping("/send")
+    public String sendMsg(@RequestBody Message message) {
+        // todo(hun): 수신한 메세지를 json형태로 다시 바꾸기
+        // todo(hun): ObjectMapper, Gson 등의 라이브러리를 이용할 것 같습니다.
+        // todo(hun): FCM에 json으로 변환한 메세지를 전송하기
+        return "";
+    }
+}

--- a/src/main/java/com/example/msglab/domain/Message.java
+++ b/src/main/java/com/example/msglab/domain/Message.java
@@ -1,0 +1,11 @@
+package com.example.msglab.domain;
+
+public class Message {
+    private final String to;
+    private final Notification notification;
+
+    public Message(String to, Notification notification) {
+        this.to = to;
+        this.notification = notification;
+    }
+}

--- a/src/main/java/com/example/msglab/domain/Notification.java
+++ b/src/main/java/com/example/msglab/domain/Notification.java
@@ -1,0 +1,11 @@
+package com.example.msglab.domain;
+
+public class Notification {
+    private final String title;
+    private final String body;
+
+    public Notification(String title, String body) {
+        this.title = title;
+        this.body = body;
+    }
+}

--- a/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
+++ b/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
@@ -1,0 +1,13 @@
+package com.example.msglab.adapter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MessageControllerTest {
+
+    @Test
+    @DisplayName("POST /send 요청이 올바르게 동작하는지 테스트")
+    void test1() {
+        // todo(hun): 컨텍스트 안띄우고 테스트하는 방법 구현(기억이 안나네요..ㅎㅎ)
+    }
+}


### PR DESCRIPTION
# 배경
* 안드로이드 등의 앱으로 전송할 메세지를 HTTP의 POST를 통해 수신하는 기능을 구현했습니다.

# 구현 내용
* 도메인 패키지에 위치한 Message는 앱으로 전송할 메세지입니다. 어떤 기기 혹은 주제로 보낼지와 Notification을 포함합니다
* Notification은 앱의 알림창에 담겨있는 내용입니다, 제목과 내용이 담겨있고 이 알림창은 작게 화면에 띄워집니다.
* 브라우저 등을 이용해 앱으로 전송할 메세지를 수신하는 기본적인 RestController를 구현했습니다.