### PR TITLE
feat : 메세지 서비스 구현, json-object 매핑 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.5'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java-test-fixtures'
 }
 
 group = 'com.example'
@@ -19,6 +20,7 @@ repositories {
 }
 
 dependencies {
+    // sort by type, impl, compile, test
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/msglab/adapter/MessageController.java
+++ b/src/main/java/com/example/msglab/adapter/MessageController.java
@@ -2,7 +2,6 @@ package com.example.msglab.adapter;
 
 import com.example.msglab.application.MessageService;
 import com.example.msglab.domain.Message;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,7 +13,7 @@ public class MessageController {
 
     private final MessageService service;
     @PostMapping("/send")
-    public String sendMsg(@RequestBody Message message) throws JsonProcessingException {
+    public String sendMsg(@RequestBody Message message) {
         String id = service.send(message);
         return "sent message id : "+id;
     }

--- a/src/main/java/com/example/msglab/adapter/MessageController.java
+++ b/src/main/java/com/example/msglab/adapter/MessageController.java
@@ -1,17 +1,21 @@
 package com.example.msglab.adapter;
 
-import org.apache.logging.log4j.message.Message;
+import com.example.msglab.application.MessageService;
+import com.example.msglab.domain.Message;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class MessageController {
+
+    private final MessageService service;
     @PostMapping("/send")
-    public String sendMsg(@RequestBody Message message) {
-        // todo(hun): 수신한 메세지를 json형태로 다시 바꾸기
-        // todo(hun): ObjectMapper, Gson 등의 라이브러리를 이용할 것 같습니다.
-        // todo(hun): FCM에 json으로 변환한 메세지를 전송하기
-        return "";
+    public String sendMsg(@RequestBody Message message) throws JsonProcessingException {
+        String id = service.send(message);
+        return "sent message id : "+id;
     }
 }

--- a/src/main/java/com/example/msglab/application/MessageService.java
+++ b/src/main/java/com/example/msglab/application/MessageService.java
@@ -1,0 +1,25 @@
+package com.example.msglab.application;
+
+import com.example.msglab.domain.Message;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MessageService {
+
+    public String send(Message message) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        // todo(hun) : 변환하려는 객체의 필드가 private이면 올바르게 매핑 못해주는 경우가 있습니다.
+        //  이런 외부 라이브러리의 에러는 어디서 테스트해야 할까요?(아래와 같이 설정해줘야 올바르게 매핑됩니다.)
+        mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+
+        // todo(hun) : jsonException을 여기서 처리하면 좋을까요?
+        String data = mapper.writeValueAsString(message);
+
+        // todo(hun) : 변환한 json string을 메세지 발송기에 전달하기
+        return "-1";
+    }
+}

--- a/src/main/java/com/example/msglab/application/MessageService.java
+++ b/src/main/java/com/example/msglab/application/MessageService.java
@@ -1,23 +1,22 @@
 package com.example.msglab.application;
 
 import com.example.msglab.domain.Message;
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MessageService {
 
+    private final Logger logger = LoggerFactory.getLogger(MessageService.class);
     private final ObjectMapper mapper = new ObjectMapper();
-    public String send(Message message) throws JsonProcessingException {
-        // todo(hun) : 변환하려는 객체의 필드가 private이면 올바르게 매핑 못해주는 경우가 있습니다.
-        //  이런 외부 라이브러리의 에러는 어디서 테스트해야 할까요?(아래와 같이 설정해줘야 올바르게 매핑됩니다.)
-        mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-
-        // todo(hun) : jsonException을 여기서 처리하면 좋을까요?
-        String data = mapper.writeValueAsString(message);
+    public String send(Message message) {
+        try {
+            String data = mapper.writeValueAsString(message);
+        } catch (Exception e) {
+            logger.warn(e.getMessage());
+        }
 
         // todo(hun) : 변환한 json string을 메세지 발송기에 전달하기
         return "-1";

--- a/src/main/java/com/example/msglab/application/MessageService.java
+++ b/src/main/java/com/example/msglab/application/MessageService.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class MessageService {
 
+    private final ObjectMapper mapper = new ObjectMapper();
     public String send(Message message) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
         // todo(hun) : 변환하려는 객체의 필드가 private이면 올바르게 매핑 못해주는 경우가 있습니다.
         //  이런 외부 라이브러리의 에러는 어디서 테스트해야 할까요?(아래와 같이 설정해줘야 올바르게 매핑됩니다.)
         mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);

--- a/src/main/java/com/example/msglab/domain/Message.java
+++ b/src/main/java/com/example/msglab/domain/Message.java
@@ -1,15 +1,13 @@
 package com.example.msglab.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
-@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class Message {
-    private final String to;
-    private final Notification notification;
-
-    public Message(@JsonProperty("to") String to, @JsonProperty("notification") Notification notification) {
-        this.to = to;
-        this.notification = notification;
-    }
+    private String to;
+    private Notification notification;
 }

--- a/src/main/java/com/example/msglab/domain/Message.java
+++ b/src/main/java/com/example/msglab/domain/Message.java
@@ -1,13 +1,13 @@
 package com.example.msglab.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
+@Getter
 public class Message {
     private final String to;
     private final Notification notification;
 
-    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public Message(@JsonProperty("to") String to, @JsonProperty("notification") Notification notification) {
         this.to = to;
         this.notification = notification;

--- a/src/main/java/com/example/msglab/domain/Message.java
+++ b/src/main/java/com/example/msglab/domain/Message.java
@@ -1,10 +1,14 @@
 package com.example.msglab.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Message {
     private final String to;
     private final Notification notification;
 
-    public Message(String to, Notification notification) {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public Message(@JsonProperty("to") String to, @JsonProperty("notification") Notification notification) {
         this.to = to;
         this.notification = notification;
     }

--- a/src/main/java/com/example/msglab/domain/Notification.java
+++ b/src/main/java/com/example/msglab/domain/Notification.java
@@ -1,15 +1,14 @@
 package com.example.msglab.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
-@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 public class Notification {
-    private final String title;
-    private final String body;
-
-    public Notification(@JsonProperty("title") String title, @JsonProperty("body") String body) {
-        this.title = title;
-        this.body = body;
-    }
+    private String title;
+    private String body;
 }

--- a/src/main/java/com/example/msglab/domain/Notification.java
+++ b/src/main/java/com/example/msglab/domain/Notification.java
@@ -1,13 +1,13 @@
 package com.example.msglab.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
+@Getter
 public class Notification {
     private final String title;
     private final String body;
 
-    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public Notification(@JsonProperty("title") String title, @JsonProperty("body") String body) {
         this.title = title;
         this.body = body;

--- a/src/main/java/com/example/msglab/domain/Notification.java
+++ b/src/main/java/com/example/msglab/domain/Notification.java
@@ -1,10 +1,14 @@
 package com.example.msglab.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Notification {
     private final String title;
     private final String body;
 
-    public Notification(String title, String body) {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public Notification(@JsonProperty("title") String title, @JsonProperty("body") String body) {
         this.title = title;
         this.body = body;
     }

--- a/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
+++ b/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
@@ -25,7 +25,5 @@ class MessageControllerTest {
         mockMvc.perform(post("/send").contentType("application/json").content(JsonRequestDummy.value))
             .andExpect(content().string("sent message id : null"))
             .andExpect(status().isOk());
-
-        verify(mock, times(1)).send(any());
     }
 }

--- a/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
+++ b/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
@@ -1,9 +1,6 @@
 package com.example.msglab.adapter;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
+++ b/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
@@ -1,13 +1,31 @@
 package com.example.msglab.adapter;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.msglab.JsonRequestDummy;
+import com.example.msglab.application.MessageService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class MessageControllerTest {
 
     @Test
     @DisplayName("POST /send 요청이 올바르게 동작하는지 테스트")
-    void test1() {
-        // todo(hun): 컨텍스트 안띄우고 테스트하는 방법 구현(기억이 안나네요..ㅎㅎ)
+    void test1() throws Exception {
+        MessageService mock = mock(MessageService.class);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new MessageController(mock)).build();
+        mockMvc.perform(post("/send").contentType("application/json").content(JsonRequestDummy.value))
+            .andExpect(content().string("sent message id : null"))
+            .andExpect(status().isOk());
+
+        verify(mock, times(1)).send(any());
     }
 }

--- a/src/test/java/com/example/msglab/application/MessageServiceTest.java
+++ b/src/test/java/com/example/msglab/application/MessageServiceTest.java
@@ -3,11 +3,13 @@ package com.example.msglab.application;
 import com.example.msglab.MessageDummy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MessageServiceTest {
 
     @Test
+    @DisplayName("메세지 서비스의 send 메소드가 올바르게 동작하는지 테스트")
     void test1() throws JsonProcessingException {
         MessageService messageService = new MessageService();
         String id = messageService.send(MessageDummy.message);

--- a/src/test/java/com/example/msglab/application/MessageServiceTest.java
+++ b/src/test/java/com/example/msglab/application/MessageServiceTest.java
@@ -12,7 +12,6 @@ class MessageServiceTest {
     @DisplayName("메세지 서비스의 send 메소드가 올바르게 동작하는지 테스트")
     void test1() throws JsonProcessingException {
         MessageService messageService = new MessageService();
-        String id = messageService.send(MessageDummy.message);
-        Assertions.assertEquals("-1", id);
+        // todo(hun): 이후 작업에서 서비스의 내용이 채워지면, 테스트 추가하기
     }
 }

--- a/src/test/java/com/example/msglab/application/MessageServiceTest.java
+++ b/src/test/java/com/example/msglab/application/MessageServiceTest.java
@@ -1,0 +1,16 @@
+package com.example.msglab.application;
+
+import com.example.msglab.MessageDummy;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MessageServiceTest {
+
+    @Test
+    void test1() throws JsonProcessingException {
+        MessageService messageService = new MessageService();
+        String id = messageService.send(MessageDummy.message);
+        Assertions.assertEquals("-1", id);
+    }
+}

--- a/src/testFixtures/java/com/example/msglab/JsonRequestDummy.java
+++ b/src/testFixtures/java/com/example/msglab/JsonRequestDummy.java
@@ -1,0 +1,11 @@
+package com.example.msglab;
+
+public class JsonRequestDummy {
+    public static String value = "{\n"
+        + "  \"to\": \"/topics/news\",\n"
+        + "  \"notification\": {\n"
+        + "    \"title\": \"Breaking News\",\n"
+        + "    \"body\": \"asdad\"\n"
+        + "  }\n"
+        + "}";
+}

--- a/src/testFixtures/java/com/example/msglab/MessageDummy.java
+++ b/src/testFixtures/java/com/example/msglab/MessageDummy.java
@@ -1,0 +1,12 @@
+package com.example.msglab;
+
+import com.example.msglab.domain.Message;
+import com.example.msglab.domain.Notification;
+
+public class MessageDummy extends Message{
+    public static Message message = new Message("to", new Notification("title", "body"));
+
+    public MessageDummy(String to, Notification notification) {
+        super(to, notification);
+    }
+}


### PR DESCRIPTION
동기 및 구현
#5 이슈를 해결하기 위해 아래와 같은 작업을 했습니다.
용이한 테스트를 위해 test-fixture 도입
객체 생성에 필요한 각종 dummy 제작
json-object 매핑을 위해 스프링에 포함되어있는 jackson 라이브러리 활용
서비스 레이어를 구현했고, 여기서 json-object 매핑 수행

결과
#5 이슈를 해결