### PR TITLE
feat: Message의 Notification.title에 validation 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,13 @@ repositories {
 dependencies {
     // sort by type, impl, compile, test
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/msglab/adapter/MessageController.java
+++ b/src/main/java/com/example/msglab/adapter/MessageController.java
@@ -2,19 +2,37 @@ package com.example.msglab.adapter;
 
 import com.example.msglab.application.MessageService;
 import com.example.msglab.domain.Message;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.DataBinder;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * push message 전송하는 컨트롤러입니다.
+ */
 @RestController
 @RequiredArgsConstructor
 public class MessageController {
 
     private final MessageService service;
-    @PostMapping("/send")
-    public String sendMsg(@RequestBody Message message) {
+
+    @InitBinder
+    private void initDirectFieldAccess(DataBinder dataBinder) {
+        dataBinder.initDirectFieldAccess();
+    }
+
+    /**
+     * push message를 전송합니다
+     *
+     * @param message 전송할 메세지
+     * @return 전송 이후 리턴하는 문자열
+     */
+    @PostMapping("/push-message")
+    public String sendMsg(@RequestBody @Valid Message message) {
         String id = service.send(message);
-        return "sent message id : "+id;
+        return "sent push-message id : "+id;
     }
 }

--- a/src/main/java/com/example/msglab/domain/Message.java
+++ b/src/main/java/com/example/msglab/domain/Message.java
@@ -1,6 +1,7 @@
 package com.example.msglab.domain;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import javax.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
@@ -9,5 +10,6 @@ import lombok.NoArgsConstructor;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class Message {
     private String to;
+    @Valid
     private Notification notification;
 }

--- a/src/main/java/com/example/msglab/domain/Notification.java
+++ b/src/main/java/com/example/msglab/domain/Notification.java
@@ -2,6 +2,7 @@ package com.example.msglab.domain;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import javax.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
 public class Notification {
+    @NotEmpty
     private String title;
     private String body;
 }

--- a/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
+++ b/src/test/java/com/example/msglab/adapter/MessageControllerTest.java
@@ -15,12 +15,21 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class MessageControllerTest {
 
     @Test
-    @DisplayName("POST /send 요청이 올바르게 동작하는지 테스트")
+    @DisplayName("정상 데이터에 대해 POST /push-message 요청이 동작하는지 테스트")
     void test1() throws Exception {
         MessageService mock = mock(MessageService.class);
         MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new MessageController(mock)).build();
-        mockMvc.perform(post("/send").contentType("application/json").content(JsonRequestDummy.value))
-            .andExpect(content().string("sent message id : null"))
+        mockMvc.perform(post("/push-message").contentType("application/json").content(JsonRequestDummy.correctValue))
+            .andExpect(content().string("sent push-message id : null"))
             .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("비정상 데이터에 대해 POST /push-message 요청이 동작하는지 테스트")
+    void test2() throws Exception {
+        MessageService mock = mock(MessageService.class);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new MessageController(mock)).build();
+        mockMvc.perform(post("/push-message").contentType("application/json").content(JsonRequestDummy.NotCorrectValue))
+            .andExpect(status().is4xxClientError());
     }
 }

--- a/src/testFixtures/java/com/example/msglab/JsonRequestDummy.java
+++ b/src/testFixtures/java/com/example/msglab/JsonRequestDummy.java
@@ -1,10 +1,18 @@
 package com.example.msglab;
 
 public class JsonRequestDummy {
-    public static String value = "{\n"
+    public static String correctValue = "{\n"
         + "  \"to\": \"/topics/news\",\n"
         + "  \"notification\": {\n"
         + "    \"title\": \"Breaking News\",\n"
+        + "    \"body\": \"asdad\"\n"
+        + "  }\n"
+        + "}";
+
+    public static String NotCorrectValue = "{\n"
+        + "  \"to\": \"/topics/news\",\n"
+        + "  \"notification\": {\n"
+        + "    \"title\": \"\",\n"
         + "    \"body\": \"asdad\"\n"
         + "  }\n"
         + "}";


### PR DESCRIPTION
동기
#11 이슈를 해결하기 위해 validation 로직을 추가했습니다.

수정 내용
추가 initDirectFieldAccess : getter 없이도 해당 필드에 접근하여 validation 수행 추가 spring-starter-validation
추가 JsonRequestDummy.NotCorrectValue : 올바르지 않은 데이터
추가 Message의 Notification 필드에 @Valid 어노테이션으로 validation이 하위로 전파되게 구현 추가 Notification.title에 NotEmpty 검증
수정 /send -> /push-message Rest api 적용

결과
클라이언트에서 보내는 메세지에 담긴, 노티피케이션의 title에 대한 검증을 할 수 있습니다.
또한 추가적인 작업으로 다른 private 필드에 대해서도 getter 없이 검증을 추가할 수 잇습니다.