### PR TITLE
모니터링 시스템 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,17 +20,17 @@ repositories {
 }
 
 dependencies {
-    // sort by type, impl, compile, test
+    // sort by type, impl, test
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-    runtimeOnly 'com.h2database:h2'
+    implementation 'com.h2database:h2'
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
@@ -46,7 +46,7 @@ dependencies {
 
     testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
 
-    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation 'com.mysql:mysql-connector-j:8.0.31'
 
     testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM prom/prometheus
+COPY ./prometheus.yml /prometheus
+CMD [ "--config.file=/prometheus/prometheus.yml" ]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+services:
+  prometheus:
+    build: .
+    ports: 
+      - "9090:9090"
+    tty: true
+  grafana:
+    image: grafana/grafana:6.6.2
+    ports:
+      - 9900:3000
+    depends_on:
+      - prometheus

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,11 +1,11 @@
 global:
-  scrape_interval:     10s
+  scrape_interval:     1s
  
 scrape_configs:
   - job_name: 'spring--app'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8080']
+      - targets: ['host.docker.internal:8081']
   - job_name: 'node'
     static_configs:
         - targets: ['host.docker.internal:9100']

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval:     10s
+ 
+scrape_configs:
+  - job_name: 'spring--app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+  - job_name: 'node'
+    static_configs:
+        - targets: ['host.docker.internal:9100']

--- a/src/main/java/com/example/msglab/adapter/config/RetryConfig.java
+++ b/src/main/java/com/example/msglab/adapter/config/RetryConfig.java
@@ -9,7 +9,6 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,7 @@ spring:
     generate-ddl: true
     hibernate:
       ddl-auto: create
+    show-sql: true
 
 fcm:
   auth: authkey

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,24 @@
 spring:
   profiles:
     active: real
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create
 management:
   endpoints:
     web:
       exposure:
         include: health, info, metrics, prometheus
+  server:
+    port: 8081
+server:
+  tomcat:
+    connection-timeout: 6000
+    threads:
+      max: 100
+      min-spare: 40
+    accept-count: 3
+    max-connections: 300
+    mbeanregistry:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   profiles:
-    active: dev
+    active: real
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus


### PR DESCRIPTION
배경
#23 이슈의 첫번째 단계입니다.

작업 내용
수정: application.yml 엔드포인트를 열었습니다.
수정: application-dev.yml show-sql을 true 설정
추가: build.gradle에 prometheus 의존성 추가
추가: docker-compose.yml 프로메테우스와 그라파나를 도커로 실행
추가: Dockerfile 프로메테우스 설정과 함게 실행되도록 추가
추가: prometheus.yml 프로메테우스 설정 추가

결과
promethus와 grafana를 이용하여 모니터링할 수 있습니다.

<img width="1342" alt="Screenshot 2022-12-19 at 6 10 50 PM" src="https://user-images.githubusercontent.com/46879264/208389530-4c61d416-ad37-4607-952a-0d894ead4ca6.png">
