### PR TITLE
RabbitMQ 설정을 공통 모듈로 이동, create 단계

### DIFF
--- a/MSG-lab-api/build.gradle
+++ b/MSG-lab-api/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.amqp:spring-rabbit'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     implementation 'com.google.guava:guava:31.1-jre'
 

--- a/MSG-lab-common/build.gradle
+++ b/MSG-lab-common/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+}
+
+jar {
+    enabled = false
+}
+
+group 'com.example'
+version '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/MSG-lab-common/src/main/java/com/example/common/config/RabbitProperty.java
+++ b/MSG-lab-common/src/main/java/com/example/common/config/RabbitProperty.java
@@ -1,0 +1,17 @@
+package com.example.common.config;
+
+import lombok.Getter;
+
+@Getter
+public enum RabbitProperty {
+
+    EXCHANGE_NAME("simple.news"),
+    QUEUE_NAME("simple.news"),
+    ROUTING_KEY("simple.news.#");
+
+    private final String value;
+
+    RabbitProperty(String value) {
+        this.value = value;
+    }
+}

--- a/MSG-lab-worker/build.gradle
+++ b/MSG-lab-worker/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.amqp:spring-rabbit'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     implementation 'com.h2database:h2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,5 @@
-plugins {
-    id 'java'
-    id 'checkstyle'
-}
-
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
 
 allprojects {
     repositories {
@@ -25,30 +19,7 @@ subprojects {
     }
 
     dependencies {
-        implementation 'org.springframework.amqp:spring-rabbit'
-        implementation 'org.springframework.boot:spring-boot-starter-actuator'
-        testImplementation 'org.springframework.boot:spring-boot-starter-test'
-        annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-
-        implementation 'org.projectlombok:lombok'
-        annotationProcessor 'org.projectlombok:lombok'
+        implementation 'org.projectlombok:lombok:1.18.24'
+        annotationProcessor 'org.projectlombok:lombok:1.18.24'
     }
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
-
-checkstyleTest {
-    enabled = false
-}
-
-dependencies {
-
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java'
+}
+
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = 'MSG-lab'
 
 include 'MSG-lab-worker'
 include 'MSG-lab-api'
+include 'MSG-lab-common'


### PR DESCRIPTION
배경
#70 이슈를 해결합니다.
create-delete 방식으로 하위 모듈에 중복으로 존재하는 코드를 공통 모듈로 분리합니다.
이번 PR에서는 필요한 소스코드를 create했습니다.

작업 내용
추가(common 모듈의 RabbitProperty): api, worker 모듈에 중복으로 존재하는 설정을 공통 모듈로 이동 추가(common 모듈의 build.gradle): 설정 추가
수정(root 모듈의 build.gradle): 불필요한 플러그인과 설정 삭제, 필요한 의존성만 하위 모듈에 주입 수정(api, worker 모듈의 build.gradle): root 모듈에서 주입해주던 spring 의존성을 직접 설정하게 변경

결과
중복으로 존재하여 서로 sync 맞춰야하는 필요가 없어집니다.